### PR TITLE
Fix label casing on account and network status

### DIFF
--- a/angular/src/app/account/account.component.html
+++ b/angular/src/app/account/account.component.html
@@ -146,7 +146,7 @@
                 <mat-card-content>
                     <p>Height: {{networkStatus.blockHeight}}</p>
                     <p>Relay Fee: {{networkStatus.node.network.relayFee}}</p>
-                    <p>Memory pool: {{networkStatus.node.transactionsInPool}} transactions</p>
+                    <p>Memory Pool: {{networkStatus.node.transactionsInPool}} transactions</p>
                     <p>Connections (on the indexer): {{networkStatus.node.network.connections}}</p>
                 </mat-card-content>
             </mat-card>

--- a/angular/src/app/account/transaction/transaction.component.html
+++ b/angular/src/app/account/transaction/transaction.component.html
@@ -19,7 +19,7 @@
 
     <p>Block Height: {{transaction.details.blockIndex}}</p>
 
-    <p class="wrap">Block hash: {{transaction.details.blockHash}}</p>
+    <p class="wrap">Block Hash: {{transaction.details.blockHash}}</p>
 
     <p>Inputs ({{transaction.details.inputs.length}}): {{transaction.details.inputsAmount | amount}}</p>
 


### PR DESCRIPTION
Small fix to make labels all title case, as there's a mixture of title case and sentence case