### PR TITLE
Return the version of electron packages to the default version

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,27 +1,27 @@
 {
-  "name": "blockcore-extension",
+  "name": "blockcore-wallet",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "blockcore-extension",
+      "name": "blockcore-wallet",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-community/electron": "^4.1.0",
-        "chokidar": "~3.5.3",
+        "chokidar": "~3.5.2",
         "electron-is-dev": "~2.0.0",
         "electron-serve": "~1.1.0",
-        "electron-unhandled": "~4.0.1",
-        "electron-updater": "~5.0.1",
+        "electron-unhandled": "~3.0.2",
+        "electron-updater": "~4.3.9",
         "electron-window-state": "~5.0.3"
       },
       "devDependencies": {
-        "electron": "^18.1.0",
-        "electron-builder": "~23.0.3",
-        "electron-rebuild": "^3.2.7",
-        "typescript": "~4.6.3"
+        "electron": "^14.0.0",
+        "electron-builder": "~22.11.7",
+        "electron-rebuild": "^3.2.3",
+        "typescript": "~4.3.5"
       }
     },
     "node_modules/@capacitor-community/electron": {
@@ -150,18 +150,16 @@
       }
     },
     "node_modules/@electron/universal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
-      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
+      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.1.0",
+        "asar": "^3.0.3",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1",
-        "minimatch": "^3.0.4",
-        "plist": "^3.0.4"
+        "fs-extra": "^9.0.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -465,9 +463,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
-      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA==",
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
       "dev": true
     },
     "node_modules/@types/plist": {
@@ -637,31 +635,30 @@
       }
     },
     "node_modules/app-builder-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
-      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
+      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
-      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.11.11.tgz",
+      "integrity": "sha512-sdOvTPKERzPJtC8ipaYTQJHW9NDl0jAB4MuxixtFrZheHUwd+QI/1oRLtspZHacmk2kqa+lULVTm9Qfj4N2blw==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.2.0",
+        "@electron/universal": "1.0.5",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.2",
-        "form-data": "^4.0.0",
+        "electron-osx-sign": "^0.5.0",
+        "electron-publish": "22.11.11",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
         "is-ci": "^3.0.0",
@@ -804,12 +801,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1040,23 +1031,20 @@
       "dev": true
     },
     "node_modules/builder-util": {
-      "version": "23.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
-      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.11.11.tgz",
+      "integrity": "sha512-2UJjOuPXhix68mmQ9hkv9G52Y0EVB8RPjlJF61jr3/tLIyd3UiJmEEhKttu8F+JVHKj8myz1MWw2/keJE/Nh+w==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "4.0.0",
+        "app-builder-bin": "3.7.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
-        "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
         "is-ci": "^3.0.0",
         "js-yaml": "^4.1.0",
         "source-map-support": "^0.5.19",
@@ -1065,24 +1053,16 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
-      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
+      "version": "8.7.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.10.tgz",
+      "integrity": "sha512-zelTRebsOsj33pF+Jf/qwpvx9W6CeMQshqaRa70Ii6+NQGsspMXqlKDQb+1lvTv9aWARxa3+jy/syzm8jTE8Kw==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/builder-util/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/builder-util/node_modules/fs-extra": {
@@ -1097,20 +1077,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/builder-util/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/builder-util/node_modules/jsonfile": {
@@ -1426,18 +1392,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -1635,15 +1589,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -1718,14 +1663,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
-      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.11.11.tgz",
+      "integrity": "sha512-4ew0c1G8bTZ14k2Nn++AHGDyEQ2rfay2YSguVvynnsD4rke6IGASQd8x6njP9t/SrEJOIQQpIKmEN/9tXJQoGw==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "23.0.3",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "app-builder-lib": "22.11.11",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -1836,14 +1781,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.1.0.tgz",
-      "integrity": "sha512-P55wdHNTRMo7a/agC84ZEZDYEK/pTBcQdlp8lFbHcx3mO4Kr+Im/J5p2uQgiuXtown31HqNh2paL3V0p+E6rpQ==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.9.tgz",
+      "integrity": "sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^16.11.26",
+        "@electron/get": "^1.0.1",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -1854,17 +1799,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
-      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.11.11.tgz",
+      "integrity": "sha512-yTD+u3uDnAov7xmniYn6zvNOcmzYhBL6n3iZmyPt+1UzMxhrkvSuEPJeuMPFD5s5D4FNBX4r0vAI4tv3SbWnnA==",
       "dev": true,
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.0.3",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "app-builder-lib": "22.11.11",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.0.3",
+        "dmg-builder": "22.11.11",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -1915,9 +1860,9 @@
       }
     },
     "node_modules/electron-osx-sign": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
-      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
+      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
       "dev": true,
       "dependencies": {
         "bluebird": "^3.5.0",
@@ -1963,14 +1908,14 @@
       "dev": true
     },
     "node_modules/electron-publish": {
-      "version": "23.0.2",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
-      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.11.11.tgz",
+      "integrity": "sha512-XINI2yz7DpForvLDENr1zfi6yW+O3ufeIgNCg/nkqiD3tBM44AokgY3aYURzsi93ZwFscoQkR2LhmHDvn30oAw==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -2258,58 +2203,46 @@
       "integrity": "sha512-tQJBCbXKoKCfkBC143QCqnEtT1s8dNE2V+b/82NF6lxnGO/2Q3a3GSLHtKl3iEDQgdzTf9pH7p418xq2rXbz1Q=="
     },
     "node_modules/electron-unhandled": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/electron-unhandled/-/electron-unhandled-4.0.1.tgz",
-      "integrity": "sha512-6BsLnBg+i96eUnbaIFZyYdyfNX3f80/Nlfqy34YEMxXT9JP3ddNsNnUeiOF8ezN4+et4t4D37gjghKTP0V3jyw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/electron-unhandled/-/electron-unhandled-3.0.2.tgz",
+      "integrity": "sha512-IIqXnM5eNgV7k5sDA/GZ39ygJbpfF3WTArNGQ1TB4AI6ajQuuVztA0M6Mq9uEpmTh5gz4nR+YsTNWYsHLoM5rw==",
       "dependencies": {
         "clean-stack": "^2.1.0",
-        "electron-is-dev": "^2.0.0",
+        "electron-is-dev": "^1.0.1",
         "ensure-error": "^2.0.0",
-        "lodash.debounce": "^4.0.8",
-        "serialize-error": "^8.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "lodash.debounce": "^4.0.8"
       }
     },
-    "node_modules/electron-unhandled/node_modules/serialize-error": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-unhandled/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/electron-unhandled/node_modules/electron-is-dev": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
     },
     "node_modules/electron-updater": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.1.tgz",
-      "integrity": "sha512-dNnXPCqYmergXy3jgg4UICuD50Orug9GQe/5xfHy+BE2Fy0icB0QE+y6iQWdCDf7yeONxwMBf4HgIkGG5pIaVg==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.10.tgz",
+      "integrity": "sha512-aE8ON9ek34reYCN1exJNHoI/8o450UBkWBeSotP+aRzokKs5ej+ipq3CgzqaiAncBWEY/spq0ohOq9MVPYVk1w==",
       "dependencies": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "8.7.7",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.5"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "8.7.7",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.7.tgz",
+      "integrity": "sha512-RUfoXzVrmFFI0K/Oft0CtP1LpTIOlBeLJatt5DePTI0KlxE156am4SGUpqtbbdqZNm++LkV9mX4olBDcXyGPow==",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -2565,20 +2498,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -4790,9 +4709,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5216,18 +5135,16 @@
       }
     },
     "@electron/universal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
-      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
+      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.1.0",
+        "asar": "^3.0.3",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1",
-        "minimatch": "^3.0.4",
-        "plist": "^3.0.4"
+        "fs-extra": "^9.0.1"
       }
     },
     "@gar/promisify": {
@@ -5472,9 +5389,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
-      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA==",
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
       "dev": true
     },
     "@types/plist": {
@@ -5617,31 +5534,30 @@
       }
     },
     "app-builder-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
-      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
+      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
-      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.11.11.tgz",
+      "integrity": "sha512-sdOvTPKERzPJtC8ipaYTQJHW9NDl0jAB4MuxixtFrZheHUwd+QI/1oRLtspZHacmk2kqa+lULVTm9Qfj4N2blw==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.2.0",
+        "@electron/universal": "1.0.5",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.2",
-        "form-data": "^4.0.0",
+        "electron-osx-sign": "^0.5.0",
+        "electron-publish": "22.11.11",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
         "is-ci": "^3.0.0",
@@ -5755,12 +5671,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "at-least-node": {
@@ -5932,23 +5842,20 @@
       "dev": true
     },
     "builder-util": {
-      "version": "23.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
-      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.11.11.tgz",
+      "integrity": "sha512-2UJjOuPXhix68mmQ9hkv9G52Y0EVB8RPjlJF61jr3/tLIyd3UiJmEEhKttu8F+JVHKj8myz1MWw2/keJE/Nh+w==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "4.0.0",
+        "app-builder-bin": "3.7.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
-        "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
         "is-ci": "^3.0.0",
         "js-yaml": "^4.1.0",
         "source-map-support": "^0.5.19",
@@ -5956,12 +5863,6 @@
         "temp-file": "^3.4.0"
       },
       "dependencies": {
-        "@tootallnate/once": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5971,17 +5872,6 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-          "dev": true,
-          "requires": {
-            "@tootallnate/once": "2",
-            "agent-base": "6",
-            "debug": "4"
           }
         },
         "jsonfile": {
@@ -5997,9 +5887,10 @@
       }
     },
     "builder-util-runtime": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
-      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
+      "version": "8.7.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.10.tgz",
+      "integrity": "sha512-zelTRebsOsj33pF+Jf/qwpvx9W6CeMQshqaRa70Ii6+NQGsspMXqlKDQb+1lvTv9aWARxa3+jy/syzm8jTE8Kw==",
+      "dev": true,
       "requires": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -6223,15 +6114,6 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -6390,12 +6272,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -6454,14 +6330,14 @@
       }
     },
     "dmg-builder": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
-      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.11.11.tgz",
+      "integrity": "sha512-4ew0c1G8bTZ14k2Nn++AHGDyEQ2rfay2YSguVvynnsD4rke6IGASQd8x6njP9t/SrEJOIQQpIKmEN/9tXJQoGw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "23.0.3",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "app-builder-lib": "22.11.11",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "dmg-license": "^1.0.9",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -6545,28 +6421,28 @@
       }
     },
     "electron": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.1.0.tgz",
-      "integrity": "sha512-P55wdHNTRMo7a/agC84ZEZDYEK/pTBcQdlp8lFbHcx3mO4Kr+Im/J5p2uQgiuXtown31HqNh2paL3V0p+E6rpQ==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.9.tgz",
+      "integrity": "sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^16.11.26",
+        "@electron/get": "^1.0.1",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       }
     },
     "electron-builder": {
-      "version": "23.0.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
-      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.11.11.tgz",
+      "integrity": "sha512-yTD+u3uDnAov7xmniYn6zvNOcmzYhBL6n3iZmyPt+1UzMxhrkvSuEPJeuMPFD5s5D4FNBX4r0vAI4tv3SbWnnA==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.0.3",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "app-builder-lib": "22.11.11",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.0.3",
+        "dmg-builder": "22.11.11",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -6604,9 +6480,9 @@
       "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
     },
     "electron-osx-sign": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
-      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
+      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
@@ -6644,14 +6520,14 @@
       }
     },
     "electron-publish": {
-      "version": "23.0.2",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
-      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
+      "version": "22.11.11",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.11.11.tgz",
+      "integrity": "sha512-XINI2yz7DpForvLDENr1zfi6yW+O3ufeIgNCg/nkqiD3tBM44AokgY3aYURzsi93ZwFscoQkR2LhmHDvn30oAw==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.2",
-        "builder-util-runtime": "9.0.0",
+        "builder-util": "22.11.11",
+        "builder-util-runtime": "8.7.10",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -6863,39 +6739,30 @@
       "integrity": "sha512-tQJBCbXKoKCfkBC143QCqnEtT1s8dNE2V+b/82NF6lxnGO/2Q3a3GSLHtKl3iEDQgdzTf9pH7p418xq2rXbz1Q=="
     },
     "electron-unhandled": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/electron-unhandled/-/electron-unhandled-4.0.1.tgz",
-      "integrity": "sha512-6BsLnBg+i96eUnbaIFZyYdyfNX3f80/Nlfqy34YEMxXT9JP3ddNsNnUeiOF8ezN4+et4t4D37gjghKTP0V3jyw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/electron-unhandled/-/electron-unhandled-3.0.2.tgz",
+      "integrity": "sha512-IIqXnM5eNgV7k5sDA/GZ39ygJbpfF3WTArNGQ1TB4AI6ajQuuVztA0M6Mq9uEpmTh5gz4nR+YsTNWYsHLoM5rw==",
       "requires": {
         "clean-stack": "^2.1.0",
-        "electron-is-dev": "^2.0.0",
+        "electron-is-dev": "^1.0.1",
         "ensure-error": "^2.0.0",
-        "lodash.debounce": "^4.0.8",
-        "serialize-error": "^8.1.0"
+        "lodash.debounce": "^4.0.8"
       },
       "dependencies": {
-        "serialize-error": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-          "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        },
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        "electron-is-dev": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+          "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
         }
       }
     },
     "electron-updater": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.1.tgz",
-      "integrity": "sha512-dNnXPCqYmergXy3jgg4UICuD50Orug9GQe/5xfHy+BE2Fy0icB0QE+y6iQWdCDf7yeONxwMBf4HgIkGG5pIaVg==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.10.tgz",
+      "integrity": "sha512-aE8ON9ek34reYCN1exJNHoI/8o450UBkWBeSotP+aRzokKs5ej+ipq3CgzqaiAncBWEY/spq0ohOq9MVPYVk1w==",
       "requires": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "8.7.7",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -6904,6 +6771,15 @@
         "semver": "^7.3.5"
       },
       "dependencies": {
+        "builder-util-runtime": {
+          "version": "8.7.7",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.7.tgz",
+          "integrity": "sha512-RUfoXzVrmFFI0K/Oft0CtP1LpTIOlBeLJatt5DePTI0KlxE156am4SGUpqtbbdqZNm++LkV9mX4olBDcXyGPow==",
+          "requires": {
+            "debug": "^4.3.2",
+            "sax": "^1.2.4"
+          }
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -7118,17 +6994,6 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -8810,9 +8675,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unique-filename": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -22,18 +22,18 @@
   },
   "dependencies": {
     "@capacitor-community/electron": "^4.1.0",
-    "chokidar": "~3.5.3",
+    "chokidar": "~3.5.2",
     "electron-is-dev": "~2.0.0",
     "electron-serve": "~1.1.0",
-    "electron-unhandled": "~4.0.1",
-    "electron-updater": "~5.0.1",
+    "electron-unhandled": "~3.0.2",
+    "electron-updater": "~4.3.9",
     "electron-window-state": "~5.0.3"
   },
   "devDependencies": {
-    "electron": "^18.1.0",
-    "electron-builder": "~23.0.3",
-    "electron-rebuild": "^3.2.7",
-    "typescript": "~4.6.3"
+    "electron": "^14.0.0",
+    "electron-builder": "~22.11.7",
+    "electron-rebuild": "^3.2.3",
+    "typescript": "~4.3.5"
   },
   "keywords": [
     "Blockcore",

--- a/electron/src/setup.ts
+++ b/electron/src/setup.ts
@@ -226,7 +226,6 @@ export function setupContentSecurityPolicy(customScheme: string): void {
           electronIsDev
             ? `default-src ${customScheme}://* 'unsafe-inline' devtools://* 'unsafe-eval' data: style-src * self 'unsafe-inline' blob: data: gap:; script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:; img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:; frame-src * self blob: data: gap:`
             : `default-src ${customScheme}://* style-src * self 'unsafe-inline' blob: data: gap:; script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:; img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:; frame-src * self blob: data: gap:`,
-
         ],
       },
     });


### PR DESCRIPTION
I had updated Electron to the latest version and now I notice that the capacitor works with version 14.